### PR TITLE
feat: refactor to xstate

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2450,6 +2450,15 @@
         "@xtuc/long": "4.2.2"
       }
     },
+    "@xstate/inspect": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@xstate/inspect/-/inspect-0.3.0.tgz",
+      "integrity": "sha512-XJaHLyKMFaFy/5UWah0agawd57wnXn27fUqWCvLgJocroGi/960vuIvFjKZyqji7iS0e/foCAyI6060rSaxaaw==",
+      "dev": true,
+      "requires": {
+        "fast-safe-stringify": "^2.0.7"
+      }
+    },
     "@xstate/react": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/@xstate/react/-/react-1.2.0.tgz",
@@ -6415,6 +6424,12 @@
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
       "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
+      "dev": true
+    },
+    "fast-safe-stringify": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.0.7.tgz",
+      "integrity": "sha512-Utm6CdzT+6xsDk2m8S6uL8VHxNwI6Jub+e9NYTcAms28T84pTa25GJQV9j0CY0N1rM8hK4x6grpF2BQf+2qwVA==",
       "dev": true
     },
     "fastparse": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -2450,6 +2450,15 @@
         "@xtuc/long": "4.2.2"
       }
     },
+    "@xstate/react": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@xstate/react/-/react-1.2.0.tgz",
+      "integrity": "sha512-/xJJ5UEGZmXKWvhBbSd/yIycFOTNM7crm3J/WHdjrA0JkkXLrIibr+gRdk9Frnsu4fyndFX9fxmIEYj0m8yXFQ==",
+      "requires": {
+        "use-isomorphic-layout-effect": "^1.0.0",
+        "use-subscription": "^1.3.0"
+      }
+    },
     "@xtuc/ieee754": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/@xtuc/ieee754/-/ieee754-1.2.0.tgz",
@@ -20304,11 +20313,15 @@
       "integrity": "sha512-cwESVXlO3url9YWlFW/TA9cshCEhtu7IKJ/p5soJ/gGpj7vbvFrAY/eIioQ6Dw23KjZhYgiIo8HOs1nQ2vr/oQ==",
       "dev": true
     },
+    "use-isomorphic-layout-effect": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/use-isomorphic-layout-effect/-/use-isomorphic-layout-effect-1.1.1.tgz",
+      "integrity": "sha512-L7Evj8FGcwo/wpbv/qvSfrkHFtOpCzvM5yl2KVyDJoylVuSvzphiiasmjgQPttIGBAy2WKiBNR98q8w7PiNgKQ=="
+    },
     "use-subscription": {
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/use-subscription/-/use-subscription-1.5.1.tgz",
       "integrity": "sha512-Xv2a1P/yReAjAbhylMfFplFKj9GssgTwN7RlcTxBujFQcloStWNDQdc4g4NRWH9xS4i/FDk04vQBptAXoF3VcA==",
-      "dev": true,
       "requires": {
         "object-assign": "^4.1.1"
       }
@@ -21047,6 +21060,11 @@
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
       "dev": true
+    },
+    "xstate": {
+      "version": "4.15.1",
+      "resolved": "https://registry.npmjs.org/xstate/-/xstate-4.15.1.tgz",
+      "integrity": "sha512-8dD/GnTwxUuDr/cY42vi+Enu4mpbuUXWISYJ0a9BC+cIFvqufJsepyDLS6lLsznfUP0GS5Yx9m3IQWFhAoGt/A=="
     },
     "xtend": {
       "version": "4.0.2",

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "@typescript-eslint/eslint-plugin": "^4.9.0",
     "@typescript-eslint/parser": "^4.9.0",
     "@use-it/interval": "^1.0.0",
+    "@xstate/inspect": "^0.3.0",
     "autoprefixer": "^10.0.4",
     "babel-eslint": "^10.1.0",
     "babel-plugin-transform-remove-console": "^6.9.4",

--- a/package.json
+++ b/package.json
@@ -34,11 +34,13 @@
   "types": "dist/index.d.ts",
   "dependencies": {
     "@reach/portal": "^0.12.1",
+    "@xstate/react": "^1.2.0",
     "body-scroll-lock": "^3.1.5",
     "focus-trap": "^6.2.2",
     "react-spring": "^8.0.27",
     "react-use-gesture": "^8.0.1",
-    "resize-observer-polyfill": "^1.5.1"
+    "resize-observer-polyfill": "^1.5.1",
+    "xstate": "^4.15.1"
   },
   "peerDependencies": {
     "react": "^16.14.0 || 17"

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -6,6 +6,20 @@ import { capitalize } from '../docs/utils'
 import '../docs/style.css'
 import '../src/style.css'
 
+// Setup xstate debugging, but only when in dev mode
+if (process.env.NODE_ENV === 'development') {
+  import('@xstate/inspect').then(({ inspect }) => {
+    console.log('loaded', inspect)
+    inspect({
+      url: 'https://statecharts.io/inspect',
+      iframe: false,
+    })
+    console.log(
+      '@xstate/inspect setup and running! Open https://statecharts.io/inspect in another tab to see the nitty gritty details'
+    )
+  })
+}
+
 export async function getStaticProps() {
   const [
     { version, description, homepage, name, meta = {} },

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -15,7 +15,7 @@ if (process.env.NODE_ENV === 'development' && typeof window !== 'undefined') {
       iframe: false,
     })
     console.log(
-      '@xstate/inspect setup and running! Open https://statecharts.io/inspect in another tab to see the nitty gritty details'
+      '@xstate/inspect setup and running! Open https://statecharts.io/inspect in another tab to see the nitty gritty details. It also works with the Redux DevTools, but it lacks chart visualization.'
     )
   })
 }

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -1,14 +1,15 @@
+import { inspect } from '@xstate/inspect'
 import type { InferGetStaticPropsType } from 'next'
 import type { AppProps } from 'next/app'
 import Head from 'next/head'
 import { capitalize } from '../docs/utils'
-import { inspect } from '@xstate/inspect'
+import { debugging } from '../src/utils'
 
 import '../docs/style.css'
 import '../src/style.css'
 
 // Setup xstate debugging, but only when in dev mode
-if (process.env.NODE_ENV === 'development' && typeof window !== 'undefined') {
+if (debugging) {
   inspect({
     url: 'https://statecharts.io/inspect',
     iframe: false,

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -7,7 +7,7 @@ import '../docs/style.css'
 import '../src/style.css'
 
 // Setup xstate debugging, but only when in dev mode
-if (process.env.NODE_ENV === 'development') {
+if (process.env.NODE_ENV === 'development' && typeof window !== 'undefined') {
   import('@xstate/inspect').then(({ inspect }) => {
     console.log('loaded', inspect)
     inspect({

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -2,21 +2,20 @@ import type { InferGetStaticPropsType } from 'next'
 import type { AppProps } from 'next/app'
 import Head from 'next/head'
 import { capitalize } from '../docs/utils'
+import { inspect } from '@xstate/inspect'
 
 import '../docs/style.css'
 import '../src/style.css'
 
 // Setup xstate debugging, but only when in dev mode
 if (process.env.NODE_ENV === 'development' && typeof window !== 'undefined') {
-  import('@xstate/inspect').then(({ inspect }) => {
-    inspect({
-      url: 'https://statecharts.io/inspect',
-      iframe: false,
-    })
-    console.log(
-      '@xstate/inspect setup and running! Open https://statecharts.io/inspect in another tab to see the nitty gritty details. It also works with the Redux DevTools, but it lacks chart visualization.'
-    )
+  inspect({
+    url: 'https://statecharts.io/inspect',
+    iframe: false,
   })
+  console.log(
+    '@xstate/inspect setup and running! Open https://statecharts.io/inspect in another tab to see the nitty gritty details. It also works with the Redux DevTools, but it lacks chart visualization.'
+  )
 }
 
 export async function getStaticProps() {

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -9,7 +9,6 @@ import '../src/style.css'
 // Setup xstate debugging, but only when in dev mode
 if (process.env.NODE_ENV === 'development' && typeof window !== 'undefined') {
   import('@xstate/inspect').then(({ inspect }) => {
-    console.log('loaded', inspect)
     inspect({
       url: 'https://statecharts.io/inspect',
       iframe: false,

--- a/src/BottomSheet.tsx
+++ b/src/BottomSheet.tsx
@@ -5,6 +5,7 @@
 // It also ensures that when transitioning to open on mount the state is always clean, not affected by previous states that could
 // cause race conditions.
 
+import { useMachine } from '@xstate/react'
 import React, { useEffect, useImperativeHandle, useRef } from 'react'
 import { animated } from 'react-spring'
 import { rubberbandIfOutOfBounds, useDrag } from 'react-use-gesture'
@@ -18,6 +19,7 @@ import {
   useSpring,
   useSpringInterpolations,
 } from './hooks'
+import { overlayMachine } from './machines/overlay'
 import type {
   defaultSnapProps,
   Props,
@@ -140,6 +142,19 @@ export const BottomSheet = React.forwardRef<
     findSnapRef.current = findSnap
     defaultSnapRef.current = findSnap(getDefaultSnap)
   }, [findSnap, getDefaultSnap, maxHeight, maxSnap, minSnap])
+
+  const [current, send] = useMachine(overlayMachine)
+
+  useEffect(() => {
+    if (_open) {
+      send('OPEN')
+    } else {
+      send('CLOSED')
+    }
+  }, [_open])
+  useEffect(() => {
+    console.log('current changed!', current)
+  }, [current])
 
   // Adjust the height whenever the snap points are changed due to resize events
   const springOnResize = useRef(false)

--- a/src/BottomSheet.tsx
+++ b/src/BottomSheet.tsx
@@ -31,6 +31,7 @@ import type {
   RefHandles,
   SnapPointProps,
 } from './types'
+import { debugging } from './utils'
 
 // @TODO implement AbortController to deal with race conditions
 
@@ -160,7 +161,7 @@ export const BottomSheet = React.forwardRef<
     [set]
   )
   const [current, send] = useMachine(overlayMachine, {
-    devTools: process.env.NODE_ENV === 'development',
+    devTools: debugging,
     actions: {
       onOpenCancel: useCallback(
         () => onSpringCancelRef.current?.({ type: 'OPEN' }),

--- a/src/BottomSheet.tsx
+++ b/src/BottomSheet.tsx
@@ -143,7 +143,9 @@ export const BottomSheet = React.forwardRef<
     defaultSnapRef.current = findSnap(getDefaultSnap)
   }, [findSnap, getDefaultSnap, maxHeight, maxSnap, minSnap])
 
-  const [current, send] = useMachine(overlayMachine)
+  const [current, send] = useMachine(overlayMachine, {
+    devTools: process.env.NODE_ENV === 'development',
+  })
 
   useEffect(() => {
     if (_open) {

--- a/src/BottomSheet.tsx
+++ b/src/BottomSheet.tsx
@@ -25,6 +25,7 @@ import type {
   SnapPointProps,
 } from './types'
 
+// @TODO rename to SpringBottomSheet and allow userland to import it directly, for those who want maximum control and minimal bundlesize
 export const BottomSheet = React.forwardRef<
   RefHandles,
   {
@@ -502,6 +503,9 @@ export const BottomSheet = React.forwardRef<
     <animated.div
       {...props}
       data-rsbs-root
+      // @TODO expose a state thingy, super handy for things like control over when you want the backdrop to change opacity
+      // when responding to y being out of bounds
+      //data-rsbs-state=closed|opening|open|dragging|snapping|closing
       data-rsbs-is-blocking={blocking}
       data-rsbs-is-dismissable={!!onDismiss}
       data-rsbs-has-header={!!header}

--- a/src/BottomSheet.tsx
+++ b/src/BottomSheet.tsx
@@ -497,7 +497,7 @@ export const BottomSheet = React.forwardRef<
     <animated.div
       {...props}
       data-rsbs-root
-      data-rsbs-state={publichStates.find(current.matches)}
+      data-rsbs-state={publicStates.find(current.matches)}
       data-rsbs-is-blocking={blocking}
       data-rsbs-is-dismissable={!!onDismiss}
       data-rsbs-has-header={!!header}
@@ -566,7 +566,7 @@ export const BottomSheet = React.forwardRef<
 })
 
 // Used for the data attribute, list over states available to CSS selectors
-const publichStates = [
+const publicStates = [
   'closed',
   'opening',
   'open',

--- a/src/BottomSheet.tsx
+++ b/src/BottomSheet.tsx
@@ -406,7 +406,8 @@ export const BottomSheet = React.forwardRef<
 
     if (onDismiss && closeOnTap && tap) {
       cancel()
-      onDismiss()
+      // Runs onDismiss in a timeout to avoid tap events on the backdrop from triggering click events on elements underneath
+      setTimeout(() => onDismiss(), 0)
       return memo
     }
 

--- a/src/hooks/useFocusTrap.tsx
+++ b/src/hooks/useFocusTrap.tsx
@@ -52,9 +52,9 @@ export function useFocusTrap({
         active = true
 
         await trap.activate()
-        return new Promise((resolve) =>
-          requestAnimationFrame(() => resolve(void 1))
-        )
+        // it's difficult to know exactly when focus is udpated https://github.com/focus-trap/focus-trap/blob/036a72ec48b85414dda00ec0c40d631c8f0ae5ce/index.js#L369-L371
+        // This timeout is attempting to compromise between a reasonable guess, as well as not delaying the open transition more than necessary
+        await new Promise((resolve) => setTimeout(() => resolve(void 1), 0))
       },
       deactivate: () => {
         if (!active) return

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -17,7 +17,11 @@ export const BottomSheet = forwardRef<RefHandles, Props>(function BottomSheet(
   const timerRef = useRef<ReturnType<typeof requestAnimationFrame>>()
   // The last point that the user snapped to, useful for open/closed toggling and the user defined height is remembered
   const lastSnapRef = useRef(null)
-  // Workaround annoying race condition
+  // @TODO refactor to an initialState: OPEN | CLOSED property as it's much easier to understand
+  // And informs what we should animate from. If the sheet is mounted with open = true, then initialState = OPEN.
+  // When initialState = CLOSED, then internal sheet must first render with open={false} before setting open={props.open}
+  // It's only when initialState and props.open is mismatching that a intial transition should happen
+  // If they match then transitions will only happen when a user interaction or resize event happen.
   const openRef = useRef(props.open)
 
   // Using layout effect to support cases where the bottom sheet have to appear already open, no transition

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -22,7 +22,6 @@ export const BottomSheet = forwardRef<RefHandles, Props>(function BottomSheet(
   // When initialState = CLOSED, then internal sheet must first render with open={false} before setting open={props.open}
   // It's only when initialState and props.open is mismatching that a intial transition should happen
   // If they match then transitions will only happen when a user interaction or resize event happen.
-  const openRef = useRef(props.open)
   const initialStateRef = useRef<'OPEN' | 'CLOSED'>(
     props.open ? 'OPEN' : 'CLOSED'
   )
@@ -35,7 +34,7 @@ export const BottomSheet = forwardRef<RefHandles, Props>(function BottomSheet(
 
       // Cleanup defaultOpen state on close
       return () => {
-        openRef.current = false
+        initialStateRef.current = 'CLOSED'
       }
     }
   }, [props.open])
@@ -65,7 +64,6 @@ export const BottomSheet = forwardRef<RefHandles, Props>(function BottomSheet(
       {mounted && (
         <_BottomSheet
           {...props}
-          defaultOpen={openRef.current}
           lastSnapRef={lastSnapRef}
           ref={ref}
           initialState={initialStateRef.current}

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -23,6 +23,9 @@ export const BottomSheet = forwardRef<RefHandles, Props>(function BottomSheet(
   // It's only when initialState and props.open is mismatching that a intial transition should happen
   // If they match then transitions will only happen when a user interaction or resize event happen.
   const openRef = useRef(props.open)
+  const initialStateRef = useRef<'OPEN' | 'CLOSED'>(
+    props.open ? 'OPEN' : 'CLOSED'
+  )
 
   // Using layout effect to support cases where the bottom sheet have to appear already open, no transition
   useLayoutEffect(() => {
@@ -65,6 +68,7 @@ export const BottomSheet = forwardRef<RefHandles, Props>(function BottomSheet(
           defaultOpen={openRef.current}
           lastSnapRef={lastSnapRef}
           ref={ref}
+          initialState={initialStateRef.current}
           onSpringStart={onSpringStart}
           onSpringEnd={onSpringEnd}
         />

--- a/src/machines/main.ts
+++ b/src/machines/main.ts
@@ -142,26 +142,28 @@ export const mainMachine = Machine<MainContext, MainStateSchema, MainEvent>(
             invoke: {
               id: 'onCloseStart',
               src: 'onSpringStart',
-              onDone: 'closingSmoothly',
+              onDone: 'deactivating',
             },
+            on: { OPEN: { target: '#overlay.open', actions: 'onCloseCancel' } },
+          },
+          deactivating: {
+            invoke: { src: 'deactivate', onDone: 'closingSmoothly' },
           },
           closingSmoothly: {
             invoke: { src: 'closeSmoothly', onDone: 'end' },
           },
+
           end: {
             invoke: { id: 'onCloseEnd', src: 'onSpringEnd', onDone: 'done' },
             on: {
-              SNAP: '#overlay.snapping',
-              CLOSE: '#overlay.closing',
-              DRAG: '#overlay.dragging',
+              OPEN: { target: '#overlay.opening', actions: 'onCloseCancel' },
             },
           },
           done: { type: 'final' },
         },
         on: {
-          SNAP: { target: 'snapping', actions: 'onSnapEnd' },
-          DRAG: { target: '#overlay.dragging', actions: 'onSnapCancel' },
-          CLOSE: { target: '#overlay.closing', actions: 'onSnapCancel' },
+          CLOSE: undefined,
+          OPEN: { target: '#overlay.opening', actions: 'onCloseCancel' },
         },
         onDone: 'closed',
       },
@@ -180,6 +182,9 @@ export const mainMachine = Machine<MainContext, MainStateSchema, MainEvent>(
       },
       onSnapCancel: (context, event) => {
         console.log('onSnapCancel', { context, event })
+      },
+      onCloseCancel: (context, event) => {
+        console.log('onCloseCancel', { context, event })
       },
       onOpenEnd: (context, event) => {
         console.log('onOpenCancel', { context, event })
@@ -217,6 +222,12 @@ export const mainMachine = Machine<MainContext, MainStateSchema, MainEvent>(
         await sleep()
         console.groupEnd()
       },
+      deactivate: async (context, event) => {
+        console.group('deactivate')
+        console.log({ context, event })
+        await sleep()
+        console.groupEnd()
+      },
       openSmoothly: async (context, event) => {
         console.group('openSmoothly')
         console.log({ context, event })
@@ -224,13 +235,13 @@ export const mainMachine = Machine<MainContext, MainStateSchema, MainEvent>(
         console.groupEnd()
       },
       snapSmoothly: async (context, event) => {
-        console.group('snappingSmoothly')
+        console.group('snapSmoothly')
         console.log({ context, event })
         await sleep()
         console.groupEnd()
       },
       closeSmoothly: async (context, event) => {
-        console.group('closingSmoothly')
+        console.group('closeSmoothly')
         console.log({ context, event })
         await sleep()
         console.groupEnd()

--- a/src/machines/main.ts
+++ b/src/machines/main.ts
@@ -114,8 +114,10 @@ export const mainMachine = Machine<MainContext, MainStateSchema, MainEvent>(
             },
           },
           snappingSmoothly: {
-            invoke: { src: 'openSmoothly', onDone: 'end' },
-            on: { DRAG: { target: '#overlay.dragging', actions: 'onSnapEnd' } },
+            invoke: { src: 'snapSmoothly', onDone: 'end' },
+            on: {
+              DRAG: { target: '#overlay.dragging', actions: 'onSnapCancel' },
+            },
           },
           end: {
             invoke: { id: 'onSnapEnd', src: 'onSpringEnd', onDone: 'done' },
@@ -139,6 +141,9 @@ export const mainMachine = Machine<MainContext, MainStateSchema, MainEvent>(
       },
       onOpenCancel: (context, event) => {
         console.log('onOpenCancel', { context, event })
+      },
+      onSnapCancel: (context, event) => {
+        console.log('onSnapCancel', { context, event })
       },
       onOpenEnd: (context, event) => {
         console.log('onOpenCancel', { context, event })

--- a/src/machines/main.ts
+++ b/src/machines/main.ts
@@ -47,10 +47,10 @@ type MainEvent = { type: 'OPEN' } | { type: 'CLOSE' }
 interface MainContext {
   // @TODO
 }
-
-function sleep(ms) {
+function sleep(ms = 10000) {
   return new Promise((resolve) => setTimeout(resolve, ms))
 }
+
 const cancelOpen = {
   CLOSE: { target: '#overlay.closing', actions: 'onOpenCancel' },
 }
@@ -83,11 +83,11 @@ export const mainMachine = Machine<MainContext, MainStateSchema, MainEvent>(
           },
           openingSmoothly: {
             invoke: { src: 'openSmoothly', onDone: 'end' },
-            on: { ...cancelOpen, ...openToDrag },
+            on: { ...openToDrag },
           },
           end: {
             invoke: { id: 'onOpenEnd', src: 'onSpringEnd', onDone: 'done' },
-            on: { CLOSE: '#overlay.closing' },
+            on: { CLOSE: '#overlay.closing', DRAG: '#overlay.dragging' },
           },
           done: {
             type: 'final',
@@ -96,7 +96,9 @@ export const mainMachine = Machine<MainContext, MainStateSchema, MainEvent>(
         on: { ...cancelOpen },
         onDone: 'open',
       },
-      open: {},
+      open: {
+        on: { DRAG: '#overlay.dragging' },
+      },
       dragging: {},
       snapping: { onDone: 'open' },
       closing: { onDone: 'closed' },
@@ -122,13 +124,31 @@ export const mainMachine = Machine<MainContext, MainStateSchema, MainEvent>(
       onSpringStart: async (context, event) => {
         console.group('onSpringStart')
         console.log({ context, event })
-        await sleep(1000)
+        await sleep()
         console.groupEnd()
       },
       onSpringEnd: async (context, event) => {
         console.group('onSpringEnd')
         console.log({ context, event })
-        await sleep(1000)
+        await sleep()
+        console.groupEnd()
+      },
+      renderVisuallyHidden: async (context, event) => {
+        console.group('renderVisuallyHidden')
+        console.log({ context, event })
+        await sleep()
+        console.groupEnd()
+      },
+      activate: async (context, event) => {
+        console.group('activate')
+        console.log({ context, event })
+        await sleep()
+        console.groupEnd()
+      },
+      openSmoothly: async (context, event) => {
+        console.group('openSmoothly')
+        console.log({ context, event })
+        await sleep()
         console.groupEnd()
       },
     },

--- a/src/machines/main.ts
+++ b/src/machines/main.ts
@@ -1,0 +1,70 @@
+import { Machine } from 'xstate'
+
+// This is the root machine, composing all the other machines and is the brain of the bottom sheet
+
+interface MainStateSchema {
+  states: {
+    // the overlay usually starts in the closed position
+    closed: {}
+    opening: {
+      states: {
+        start: {}
+        // staging will render the overlay in the open state, but visually hidden
+        // doing this solves two problems:
+        // on Android focusing an input element will trigger the softkeyboard to show up, which will change the viewport height
+        // on iOS the focus event will break the view by triggering a scrollIntoView event if focus happens while the overlay is below the viewport and body got overflow:hidden
+        // by rendering things with opacity 0 we ensure keyboards and scrollIntoView all happen in a way that match up with what the sheet will look like.
+        // we can then move it to the opening position below the viewport, and animate it into view without worrying about height changes or scrolling overflow:hidden events
+        staging: {}
+        end: {}
+      }
+    }
+    open: {}
+    // dragging responds to user gestures, which may interrupt the opening state, closing state or snapping
+    // when interrupting an opening event, it fires onSpringEnd(OPEN) before onSpringStart(DRAG)
+    // when interrupting a closing event, it fires onSpringCancel(CLOSE) before onSpringStart(DRAG)
+    // when interrupting a dragging event, it fires onSpringCancel(SNAP) before onSpringStart(DRAG)
+    dragging: {}
+    // snapping happens whenever transitioning to a new snap point, often after dragging
+    snapping: {}
+    closing: {}
+  }
+}
+
+type MainEvent = { type: 'OPEN' } | { type: 'CLOSE' }
+
+// The context (extended state) of the machine
+interface MainContext {
+  // @TODO
+}
+
+export const mainMachine = Machine<MainContext, MainStateSchema, MainEvent>({
+  id: 'overlay',
+  initial: 'closed',
+  context: {},
+  states: {
+    closed: { on: { OPEN: 'opening' } },
+    opening: {
+      states: {
+        start: {
+          entry: 'onSpringStart',
+        },
+        staging: {
+          invoke: [{ id: 'stage', src: 'stage' }],
+          onDone: 'end',
+        },
+        end: {
+          type: 'final',
+        },
+      },
+      on: {
+        CLOSE: { actions: 'onSpringCancel' },
+      },
+      onDone: 'open',
+    },
+    open: {},
+    dragging: {},
+    snapping: { onDone: 'open' },
+    closing: { onDone: 'closed' },
+  },
+})

--- a/src/machines/main.ts
+++ b/src/machines/main.ts
@@ -97,9 +97,12 @@ export const mainMachine = Machine<MainContext, MainStateSchema, MainEvent>(
         onDone: 'open',
       },
       open: {
-        on: { DRAG: '#overlay.dragging' },
+        on: { DRAG: '#overlay.dragging', SNAP: 'snapping' },
       },
-      dragging: {},
+      dragging: {
+        entry: 'onDrag',
+        on: { SNAP: 'snapping', DRAG: 'dragging' },
+      },
       snapping: { onDone: 'open' },
       closing: { onDone: 'closed' },
     },
@@ -117,6 +120,9 @@ export const mainMachine = Machine<MainContext, MainStateSchema, MainEvent>(
       },
       onOpenEnd: (context, event) => {
         console.log('onOpenCancel', { context, event })
+      },
+      onDrag: (context, event) => {
+        console.log('onDrag', { context, event })
       },
     },
     services: {

--- a/src/machines/main.ts
+++ b/src/machines/main.ts
@@ -51,9 +51,11 @@ interface MainContext {
 function sleep(ms) {
   return new Promise((resolve) => setTimeout(resolve, ms))
 }
-
 const cancelOpen = {
-  CLOSE: { target: '#overlay.closing', actions: 'onSpringCancel' },
+  CLOSE: { target: '#overlay.closing', actions: 'onOpenCancel' },
+}
+const openToDrag = {
+  DRAG: { target: '#overlay.dragging', actions: 'onOpenEnd' },
 }
 
 export const mainMachine = Machine<MainContext, MainStateSchema, MainEvent>(
@@ -67,28 +69,31 @@ export const mainMachine = Machine<MainContext, MainStateSchema, MainEvent>(
         initial: 'start',
         states: {
           start: {
-            invoke: { src: 'onSpringStart', onDone: 'visuallyHidden' },
-            on: { ...cancelOpen },
+            invoke: {
+              id: 'onOpenStart',
+              src: 'onSpringStart',
+              onDone: 'visuallyHidden',
+            },
           },
           visuallyHidden: {
             invoke: { src: 'renderVisuallyHidden', onDone: 'activating' },
-            on: { ...cancelOpen },
           },
           activating: {
             invoke: { src: 'activate', onDone: 'openingSmoothly' },
-            on: { ...cancelOpen },
           },
           openingSmoothly: {
             invoke: { src: 'openSmoothly', onDone: 'end' },
-            on: { ...cancelOpen },
+            on: { ...cancelOpen, ...openToDrag },
           },
           end: {
-            invoke: { src: 'onSpringEnd', onDone: 'done' },
+            invoke: { id: 'onOpenEnd', src: 'onSpringEnd', onDone: 'done' },
+            on: { CLOSE: '#overlay.closing' },
           },
           done: {
             type: 'final',
           },
         },
+        on: { ...cancelOpen },
         onDone: 'open',
       },
       open: {},
@@ -104,6 +109,12 @@ export const mainMachine = Machine<MainContext, MainStateSchema, MainEvent>(
     actions: {
       onSpringCancel: (context, event) => {
         console.log('onSpringCancel', { context, event })
+      },
+      onOpenCancel: (context, event) => {
+        console.log('onOpenCancel', { context, event })
+      },
+      onOpenEnd: (context, event) => {
+        console.log('onOpenCancel', { context, event })
       },
     },
     services: {

--- a/src/machines/main.ts
+++ b/src/machines/main.ts
@@ -58,6 +58,8 @@ const openToDrag = {
   DRAG: { target: '#overlay.dragging', actions: 'onOpenEnd' },
 }
 
+// Copy paste the machine into https://xstate.js.org/viz/ to make sense of what's going on in here ;)
+
 export const mainMachine = Machine<MainContext, MainStateSchema, MainEvent>(
   {
     id: 'overlay',
@@ -133,7 +135,36 @@ export const mainMachine = Machine<MainContext, MainStateSchema, MainEvent>(
         },
         onDone: 'open',
       },
-      closing: { onDone: 'closed' },
+      closing: {
+        initial: 'start',
+        states: {
+          start: {
+            invoke: {
+              id: 'onCloseStart',
+              src: 'onSpringStart',
+              onDone: 'closingSmoothly',
+            },
+          },
+          closingSmoothly: {
+            invoke: { src: 'closeSmoothly', onDone: 'end' },
+          },
+          end: {
+            invoke: { id: 'onCloseEnd', src: 'onSpringEnd', onDone: 'done' },
+            on: {
+              SNAP: '#overlay.snapping',
+              CLOSE: '#overlay.closing',
+              DRAG: '#overlay.dragging',
+            },
+          },
+          done: { type: 'final' },
+        },
+        on: {
+          SNAP: { target: 'snapping', actions: 'onSnapEnd' },
+          DRAG: { target: '#overlay.dragging', actions: 'onSnapCancel' },
+          CLOSE: { target: '#overlay.closing', actions: 'onSnapCancel' },
+        },
+        onDone: 'closed',
+      },
     },
     on: {
       CLOSE: 'closing',
@@ -188,6 +219,18 @@ export const mainMachine = Machine<MainContext, MainStateSchema, MainEvent>(
       },
       openSmoothly: async (context, event) => {
         console.group('openSmoothly')
+        console.log({ context, event })
+        await sleep()
+        console.groupEnd()
+      },
+      snapSmoothly: async (context, event) => {
+        console.group('snappingSmoothly')
+        console.log({ context, event })
+        await sleep()
+        console.groupEnd()
+      },
+      closeSmoothly: async (context, event) => {
+        console.group('closingSmoothly')
         console.log({ context, event })
         await sleep()
         console.groupEnd()

--- a/src/machines/main.ts
+++ b/src/machines/main.ts
@@ -52,6 +52,10 @@ function sleep(ms) {
   return new Promise((resolve) => setTimeout(resolve, ms))
 }
 
+const cancelOpen = {
+  CLOSE: { target: '#overlay.closing', actions: 'onSpringCancel' },
+}
+
 export const mainMachine = Machine<MainContext, MainStateSchema, MainEvent>(
   {
     id: 'overlay',
@@ -64,33 +68,22 @@ export const mainMachine = Machine<MainContext, MainStateSchema, MainEvent>(
         states: {
           start: {
             invoke: { src: 'onSpringStart', onDone: 'visuallyHidden' },
-            on: {
-              CLOSE: { actions: 'onSpringCancel' },
-            },
+            on: { ...cancelOpen },
           },
           visuallyHidden: {
             invoke: { src: 'renderVisuallyHidden', onDone: 'activating' },
-            on: {
-              CLOSE: { actions: 'onSpringCancel' },
-            },
+            on: { ...cancelOpen },
           },
           activating: {
             invoke: { src: 'activate', onDone: 'openingSmoothly' },
-            on: {
-              CLOSE: { actions: 'onSpringCancel' },
-            },
+            on: { ...cancelOpen },
           },
           openingSmoothly: {
             invoke: { src: 'openSmoothly', onDone: 'end' },
-            on: {
-              CLOSE: { actions: 'onSpringCancel' },
-            },
+            on: { ...cancelOpen },
           },
           end: {
             invoke: { src: 'onSpringEnd', onDone: 'done' },
-            on: {
-              CLOSE: { actions: 'onSpringCancel' },
-            },
           },
           done: {
             type: 'final',
@@ -116,12 +109,16 @@ export const mainMachine = Machine<MainContext, MainStateSchema, MainEvent>(
     services: {
       // onSpringStart|onSpringEnd will await on the prop callbacks, allowing userland to delay transitions
       onSpringStart: async (context, event) => {
-        console.log('onSpringStart', { context, event })
-        await sleep(100)
-        console.log('async test')
+        console.group('onSpringStart')
+        console.log({ context, event })
+        await sleep(1000)
+        console.groupEnd()
       },
       onSpringEnd: async (context, event) => {
-        console.log('onSpringEnd', { context, event })
+        console.group('onSpringEnd')
+        console.log({ context, event })
+        await sleep(1000)
+        console.groupEnd()
       },
     },
   }

--- a/src/machines/main.ts
+++ b/src/machines/main.ts
@@ -115,17 +115,22 @@ export const mainMachine = Machine<MainContext, MainStateSchema, MainEvent>(
           },
           snappingSmoothly: {
             invoke: { src: 'snapSmoothly', onDone: 'end' },
-            on: {
-              DRAG: { target: '#overlay.dragging', actions: 'onSnapCancel' },
-            },
           },
           end: {
             invoke: { id: 'onSnapEnd', src: 'onSpringEnd', onDone: 'done' },
-            on: { CLOSE: '#overlay.closing', DRAG: '#overlay.dragging' },
+            on: {
+              SNAP: '#overlay.snapping',
+              CLOSE: '#overlay.closing',
+              DRAG: '#overlay.dragging',
+            },
           },
           done: { type: 'final' },
         },
-        on: { CLOSE: { target: '#overlay.closing', actions: 'onSnapCancel' } },
+        on: {
+          SNAP: { target: 'snapping', actions: 'onSnapEnd' },
+          DRAG: { target: '#overlay.dragging', actions: 'onSnapCancel' },
+          CLOSE: { target: '#overlay.closing', actions: 'onSnapCancel' },
+        },
         onDone: 'open',
       },
       closing: { onDone: 'closed' },
@@ -149,7 +154,7 @@ export const mainMachine = Machine<MainContext, MainStateSchema, MainEvent>(
         console.log('onOpenCancel', { context, event })
       },
       onSnapEnd: (context, event) => {
-        console.log('onSnapCancel', { context, event })
+        console.log('onSnapEnd', { context, event })
       },
       onDrag: (context, event) => {
         console.log('onDrag', { context, event })

--- a/src/machines/overlay.ts
+++ b/src/machines/overlay.ts
@@ -36,12 +36,32 @@ interface OverlayStateSchema {
     // when interrupting a dragging event, it fires onSpringCancel(SNAP) before onSpringStart(DRAG)
     dragging: {}
     // snapping happens whenever transitioning to a new snap point, often after dragging
-    snapping: {}
-    closing: {}
+    snapping: {
+      states: {
+        start: {}
+        snappingSmoothly: {}
+        end: {}
+        done: {}
+      }
+    }
+    closing: {
+      states: {
+        start: {}
+        deactivating: {}
+        closingSmoothly: {}
+        end: {}
+        done: {}
+      }
+    }
   }
 }
 
-type OverlayEvent = { type: 'OPEN' } | { type: 'CLOSE' }
+type OverlayEvent =
+  | { type: 'OPEN' }
+  | { type: 'SNAP' }
+  | { type: 'CLOSE' }
+  | { type: 'DRAG' }
+//  | { type: 'RESIZE' }
 
 // The context (extended state) of the machine
 interface OverlayContext {
@@ -156,7 +176,6 @@ export const overlayMachine = Machine<
           closingSmoothly: {
             invoke: { src: 'closeSmoothly', onDone: 'end' },
           },
-
           end: {
             invoke: { id: 'onCloseEnd', src: 'onSpringEnd', onDone: 'done' },
             on: {

--- a/src/machines/overlay.ts
+++ b/src/machines/overlay.ts
@@ -2,7 +2,7 @@ import { Machine } from 'xstate'
 
 // This is the root machine, composing all the other machines and is the brain of the bottom sheet
 
-interface MainStateSchema {
+interface OverlayStateSchema {
   states: {
     // the overlay usually starts in the closed position
     closed: {}
@@ -41,10 +41,10 @@ interface MainStateSchema {
   }
 }
 
-type MainEvent = { type: 'OPEN' } | { type: 'CLOSE' }
+type OverlayEvent = { type: 'OPEN' } | { type: 'CLOSE' }
 
 // The context (extended state) of the machine
-interface MainContext {
+interface OverlayContext {
   // @TODO
 }
 function sleep(ms = 10000) {
@@ -60,7 +60,11 @@ const openToDrag = {
 
 // Copy paste the machine into https://xstate.js.org/viz/ to make sense of what's going on in here ;)
 
-export const mainMachine = Machine<MainContext, MainStateSchema, MainEvent>(
+export const overlayMachine = Machine<
+  OverlayContext,
+  OverlayStateSchema,
+  OverlayEvent
+>(
   {
     id: 'overlay',
     initial: 'closed',

--- a/src/machines/overlay.ts
+++ b/src/machines/overlay.ts
@@ -99,6 +99,9 @@ const cancelOpen = {
 const openToDrag = {
   DRAG: { target: '#overlay.dragging', actions: 'onOpenEnd' },
 }
+const openToResize = {
+  RESIZE: { target: '#overlay.resizing', actions: 'onOpenEnd' },
+}
 
 const initiallyOpen = ({ initialState }) => initialState === 'OPEN'
 const initiallyClosed = ({ initialState }) => initialState === 'CLOSED'
@@ -141,7 +144,7 @@ export const overlayMachine = Machine<
               },
               activating: {
                 invoke: { src: 'activate', onDone: '#overlay.opening.end' },
-                on: { ...openToDrag },
+                on: { ...openToDrag, ...openToResize },
               },
             },
           },
@@ -156,7 +159,7 @@ export const overlayMachine = Machine<
               },
               open: {
                 invoke: { src: 'openSmoothly', onDone: '#overlay.opening.end' },
-                on: { ...openToDrag },
+                on: { ...openToDrag, ...openToResize },
               },
             },
           },

--- a/src/machines/overlay.ts
+++ b/src/machines/overlay.ts
@@ -127,7 +127,7 @@ export const overlayMachine = Machine<
       },
       dragging: {
         entry: 'onDrag',
-        on: { SNAP: 'snapping', DRAG: 'dragging' },
+        on: { SNAP: 'snapping', DRAG: { actions: 'onDrag', internal: true } },
       },
       snapping: {
         initial: 'start',

--- a/src/machines/overlay.ts
+++ b/src/machines/overlay.ts
@@ -1,4 +1,4 @@
-import { Machine } from 'xstate'
+import { Machine, assign } from 'xstate'
 
 // This is the root machine, composing all the other machines and is the brain of the bottom sheet
 
@@ -80,7 +80,7 @@ interface OverlayStateSchema {
 
 type OverlayEvent =
   | { type: 'OPEN' }
-  | { type: 'SNAP' }
+  | { type: 'SNAP'; payload: { y: number; velocity: number } }
   | { type: 'CLOSE' }
   | { type: 'DRAG' }
   | { type: 'RESIZE' }
@@ -185,6 +185,13 @@ export const overlayMachine = Machine<
               src: 'onSnapStart',
               onDone: 'snappingSmoothly',
             },
+            entry: [
+              assign({
+                // @ts-expect-error
+                y: (_, { payload: { y } }) => y,
+                velocity: (_, { payload: { velocity } }) => velocity,
+              }),
+            ],
           },
           snappingSmoothly: {
             invoke: { src: 'snapSmoothly', onDone: 'end' },

--- a/src/style.css
+++ b/src/style.css
@@ -142,3 +142,9 @@
     opacity: var(--rsbs-backdrop-opacity);
   }
 }
+
+[data-rsbs-state='closed'],
+[data-rsbs-state='closing'] {
+  /* Allows interactions on the rest of the page before the close transition is finished */
+  pointer-events: none;
+}

--- a/src/style.css
+++ b/src/style.css
@@ -132,11 +132,13 @@
   padding-bottom: calc(16px + env(safe-area-inset-bottom));
 }
 
-[data-rsbs-is-dismissable='true'] [data-rsbs-header-padding],
-[data-rsbs-is-dismissable='true'] [data-rsbs-content-padding],
-[data-rsbs-is-dismissable='true'] [data-rsbs-footer-padding] {
-  opacity: var(--rsbs-content-opacity);
-}
-[data-rsbs-is-dismissable='true'] [data-rsbs-backdrop] {
-  opacity: var(--rsbs-backdrop-opacity);
+[data-rsbs-is-dismissable='true'],
+[data-rsbs-is-dismissable='false']:matches([data-rsbs-state='opening'], [data-rsbs-state='closing']) {
+  &
+    :matches([data-rsbs-header-padding], [data-rsbs-content-padding], [data-rsbs-footer-padding]) {
+    opacity: var(--rsbs-content-opacity);
+  }
+  & [data-rsbs-backdrop] {
+    opacity: var(--rsbs-backdrop-opacity);
+  }
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -24,7 +24,7 @@ type defaultSnap = (props: defaultSnapProps) => number
 
 /* Might make sense to expose a preventDefault method here */
 export type SpringEvent = {
-  type: 'OPEN' | 'CLOSE' | 'RESIZE' | 'SNAP' | 'DRAG'
+  type: 'OPEN' | 'CLOSE' | 'RESIZE' | 'SNAP'
 }
 
 export type Props = {

--- a/src/types.ts
+++ b/src/types.ts
@@ -24,7 +24,7 @@ type defaultSnap = (props: defaultSnapProps) => number
 
 /* Might make sense to expose a preventDefault method here */
 export type SpringEvent = {
-  type: 'OPEN' | 'CLOSE' | 'RESIZE'
+  type: 'OPEN' | 'CLOSE' | 'RESIZE' | 'SNAP' | 'DRAG'
 }
 
 export type Props = {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -58,3 +58,8 @@ export function processSnapPoints(unsafeSnaps: number | number[], maxHeight) {
     maxSnap,
   }
 }
+
+export const debugging =
+  process.env.NODE_ENV === 'development' && typeof window !== 'undefined'
+    ? window.location.search === '?debug'
+    : false


### PR DESCRIPTION
By refactoring out the useEffect mess and replacing it with a proper state machine the following improvements were made:
- new event type `SNAP`, fired whenever transitioning to a snap point. Usually when dragging ends, or when `ref.snapTo` got called.
- new data attribute added: `data-rsbs-state`, it can be set to any of `closed | opening | open | dragging | snapping | resizing | closing`. 
- resize events can no longer happen while closing, fixing a bug in Android when closing a bottom sheet with a soft keyboard active.