### PR TITLE
fix: remove padding wrappers

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 ![Logo with the text Accessible, Delightful and Performant](https://react-spring-bottom-sheet.cocody.dev/readme.svg)
 
-**react-spring-bottom-sheet** is built on top of **react-spring** and **react-use-gesture**. It busts the myth that accessibility and supporting keyboard navigation and screen readers are allegedly at odds with delightful, beautiful and highly animated UIs. Every animation and transition is implemented using CSS custom properties instead of manipulating them directly, allowing complete control over the experience from CSS alone.
+**react-spring-bottom-sheet** is built on top of **[react-spring]** and **[react-use-gesture]**. It busts the myth that accessibility and supporting keyboard navigation and screen readers are allegedly at odds with delightful, beautiful, and highly animated UIs. Every animation and transition use CSS custom properties instead of manipulating them directly, allowing complete control over the experience from CSS alone.
 
 # Install
 
@@ -241,3 +241,5 @@ ref.current.snapTo(({ // Showing all the available props
 [size-badge]: http://img.badgesize.io/https://unpkg.com/react-spring-bottom-sheet/dist/index.es.js?label=size&style=flat-square
 [unpkg-dist]: https://unpkg.com/react-spring-bottom-sheet/dist/
 [module-formats-badge]: https://img.shields.io/badge/module%20formats-cjs%2C%20es%2C%20modern-green.svg?style=flat-square
+[react-spring]: https://github.com/pmndrs/react-spring
+[react-use-gesture]: https://github.com/pmndrs/react-use-gesture

--- a/defaults.json
+++ b/defaults.json
@@ -9,8 +9,8 @@
     "--rsbs-max-w": "auto",
     "--rsbs-ml": "env(safe-area-inset-left)",
     "--rsbs-mr": "env(safe-area-inset-right)",
+    "--rsbs-overlay-h": "0px",
     "--rsbs-overlay-rounded": "16px",
-    "--rsbs-overlay-translate-y": "0px",
-    "--rsbs-overlay-h": "0px"
+    "--rsbs-overlay-translate-y": "0px"
   }
 }

--- a/docs/style.css
+++ b/docs/style.css
@@ -31,10 +31,10 @@
     --rsbs-mr: 0px;
 
     /* the bottom sheet doesn't need display cutout paddings when in the iframe */
-    & [data-rsbs-has-footer='false'] [data-rsbs-content-padding] {
+    & [data-rsbs-has-footer='false'] [data-rsbs-scroll] {
       padding-bottom: 0px !important;
     }
-    & [data-rsbs-footer-padding] {
+    & [data-rsbs-footer] {
       padding-bottom: 16px !important;
     }
   }

--- a/next.config.js
+++ b/next.config.js
@@ -1,1 +1,0 @@
-module.exports = {}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1331,6 +1331,11 @@
       "integrity": "sha512-CAEbWH7OIur6jEOzaai83jq3FmKmv4PmX1JYfs9IrYcGEVI/lyL1EXJGCj7eFVJ0bg5QR8LMxBlEtA+xKiLpFw==",
       "dev": true
     },
+    "@juggle/resize-observer": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@juggle/resize-observer/-/resize-observer-3.2.0.tgz",
+      "integrity": "sha512-fsLxt0CHx2HCV9EL8lDoVkwHffsA0snUpddYjdLyXcG5E41xaamn9ZyQqOE9TUJdrRlH8/hjIf+UdOdDeKCUgg=="
+    },
     "@next/env": {
       "version": "10.0.4",
       "resolved": "https://registry.npmjs.org/@next/env/-/env-10.0.4.tgz",
@@ -3041,6 +3046,16 @@
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.1.0.tgz",
       "integrity": "sha512-1Yj8h9Q+QDF5FzhMs/c9+6UntbD5MkRfRwac8DoEm9ZfUBZ7tZ55YcGVAzEe4bXsdQHEk+s9S5wsOKVdZrw0tQ==",
       "dev": true
+    },
+    "bindings": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
+      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "file-uri-to-path": "1.0.0"
+      }
     },
     "bl": {
       "version": "4.0.3",
@@ -6155,6 +6170,13 @@
         "flat-cache": "^3.0.4"
       }
     },
+    "file-uri-to-path": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
+      "dev": true,
+      "optional": true
+    },
     "filesize": {
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/filesize/-/filesize-6.1.0.tgz",
@@ -8926,6 +8948,13 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
       "dev": true
+    },
+    "nan": {
+      "version": "2.14.2",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.2.tgz",
+      "integrity": "sha512-M2ufzIiINKCuDfBSAUr1vWQ+vuVcA9kqx8JJUsbQi6yf1uGRyb7HfpdfUr5qLXf3B/t8dPvcjhKMmlfnP47EzQ==",
+      "dev": true,
+      "optional": true
     },
     "nanoid": {
       "version": "3.1.20",
@@ -16981,11 +17010,6 @@
       "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
       "dev": true
     },
-    "resize-observer-polyfill": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/resize-observer-polyfill/-/resize-observer-polyfill-1.5.1.tgz",
-      "integrity": "sha512-LwZrotdHOo12nQuZlHEmtuXdqGoOD0OhaxopaNFxWzInpEgaLWoVuAMbTzixuosCx2nEG58ngzW3vxdWoxIgdg=="
-    },
     "resolve": {
       "version": "1.19.0",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.19.0.tgz",
@@ -19801,7 +19825,11 @@
           "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.13.tgz",
           "integrity": "sha512-oWb1Z6mkHIskLzEJ/XWX0srkpkTQ7vaopMQkyaEIoq0fmtFVxOthb8cCxeT+p3ynTdkk/RZwbgG4brR5BeWECw==",
           "dev": true,
-          "optional": true
+          "optional": true,
+          "requires": {
+            "bindings": "^1.5.0",
+            "nan": "^2.12.1"
+          }
         },
         "glob-parent": {
           "version": "3.1.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1718,6 +1718,15 @@
         "picomatch": "^2.2.2"
       }
     },
+    "@rooks/use-raf": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@rooks/use-raf/-/use-raf-4.5.0.tgz",
+      "integrity": "sha512-BKIY0UZs34fT5Up3q8PP2akvBJKuX/0DXRhSmAXlfMzoNdWxA5ccZOfZPsgetUXtF4EJCNb/p9F7oRXecDawrg==",
+      "dev": true,
+      "requires": {
+        "raf": "3.4.1"
+      }
+    },
     "@semantic-release/changelog": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/@semantic-release/changelog/-/changelog-5.0.1.tgz",
@@ -13366,6 +13375,12 @@
         "sha.js": "^2.4.8"
       }
     },
+    "performance-now": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
+      "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=",
+      "dev": true
+    },
     "picomatch": {
       "version": "2.2.2",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.2.2.tgz",
@@ -16655,6 +16670,15 @@
       "resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-4.0.1.tgz",
       "integrity": "sha512-ARhCpm70fzdcvNQfPoy49IaanKkTlRWF2JMzqhcJbhSFRZv7nPTvZJdcY7301IPmvW+/p0RgIWnQDLJxifsQ7g==",
       "dev": true
+    },
+    "raf": {
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/raf/-/raf-3.4.1.tgz",
+      "integrity": "sha512-Sq4CW4QhwOHE8ucn6J34MqtZCeWFP2aQSmrlroYgqAV1PjStIhJXxYuTgUIfkEk7zTLjmIjLmU5q+fbD1NnOJA==",
+      "dev": true,
+      "requires": {
+        "performance-now": "^2.1.0"
+      }
     },
     "randombytes": {
       "version": "2.1.0",

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "react": "^16.14.0 || 17"
   },
   "devDependencies": {
+    "@rooks/use-raf": "^4.5.0",
     "@semantic-release/changelog": "^5.0.1",
     "@semantic-release/git": "^9.0.0",
     "@tailwindcss/forms": "^0.2.1",

--- a/package.json
+++ b/package.json
@@ -33,13 +33,13 @@
   ],
   "types": "dist/index.d.ts",
   "dependencies": {
+    "@juggle/resize-observer": "^3.2.0",
     "@reach/portal": "^0.12.1",
     "@xstate/react": "^1.2.0",
     "body-scroll-lock": "^3.1.5",
     "focus-trap": "^6.2.2",
     "react-spring": "^8.0.27",
     "react-use-gesture": "^8.0.1",
-    "resize-observer-polyfill": "^1.5.1",
     "xstate": "^4.15.1"
   },
   "peerDependencies": {

--- a/pages/fixtures/experiments.tsx
+++ b/pages/fixtures/experiments.tsx
@@ -380,7 +380,6 @@ function Nine() {
       >
         <SheetContent>
           <Button onClick={() => setExpandContent(true)}>Expand</Button>
-          <br />
           {expandContent && (
             <Button onClick={() => setExpandContent(false)}>No!</Button>
           )}

--- a/pages/fixtures/experiments.tsx
+++ b/pages/fixtures/experiments.tsx
@@ -1,3 +1,4 @@
+import useRaf from '@rooks/use-raf'
 import useInterval from '@use-it/interval'
 import { memo, useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import Button from '../../docs/fixtures/Button'
@@ -14,7 +15,7 @@ const MemoBottomSheet = memo(BottomSheet)
 function One() {
   const [open, setOpen] = useState(false)
 
-  const [seconds, setSeconds] = useState(1)
+  const [renders, setRenders] = useState(1)
 
   const style = useMemo(() => ({ ['--rsbs-bg' as any]: '#EFF6FF' }), [])
   const onDismiss = useCallback(() => setOpen(false), [])
@@ -37,23 +38,21 @@ function One() {
     [onDismiss]
   )
 
-  useInterval(() => {
-    if (open) {
-      setSeconds(seconds + 1)
-    }
-  }, 100)
+  useRaf(() => {
+    setRenders(renders + 1)
+  }, open)
 
   useEffect(() => {
     if (open) {
       return () => {
-        setSeconds(1)
+        setRenders(1)
       }
     }
   }, [open])
 
   return (
     <>
-      <Button onClick={() => setOpen(true)}>{seconds}</Button>
+      <Button onClick={() => setOpen(true)}>{renders}</Button>
       <MemoBottomSheet
         style={style}
         open={open}

--- a/src/BottomSheet.tsx
+++ b/src/BottomSheet.tsx
@@ -556,7 +556,6 @@ export const BottomSheet = React.forwardRef<
           </div>
         )}
       </div>
-      <div key="antigap" data-rsbs-antigap />
     </animated.div>
   )
 })

--- a/src/BottomSheet.tsx
+++ b/src/BottomSheet.tsx
@@ -89,7 +89,7 @@ export const BottomSheet = React.forwardRef<
   const [spring, set] = useSpring()
 
   const containerRef = useRef<HTMLDivElement>(null)
-  const contentRef = useRef<HTMLDivElement>(null)
+  const scrollRef = useRef<HTMLDivElement>(null)
   const contentContainerRef = useRef<HTMLDivElement>(null)
   const headerRef = useRef<HTMLDivElement>(null)
   const footerRef = useRef<HTMLDivElement>(null)
@@ -102,7 +102,7 @@ export const BottomSheet = React.forwardRef<
 
   // "Plugins" huhuhu
   const scrollLockRef = useScrollLock({
-    targetRef: contentRef,
+    targetRef: scrollRef,
     enabled: ready && scrollLocking,
     reserveScrollBarGap,
   })
@@ -545,12 +545,8 @@ export const BottomSheet = React.forwardRef<
             {header}
           </div>
         )}
-        <div key="content" data-rsbs-content ref={contentRef}>
-          <div
-            ref={contentContainerRef}
-            // The overflow hidden is for the resize observer to get dimensions including margins and paddings
-            style={{ overflow: 'hidden' }}
-          >
+        <div key="scroll" data-rsbs-scroll ref={scrollRef}>
+          <div data-rsbs-content ref={contentContainerRef}>
             {children}
           </div>
         </div>

--- a/src/BottomSheet.tsx
+++ b/src/BottomSheet.tsx
@@ -542,7 +542,7 @@ export const BottomSheet = React.forwardRef<
       >
         {header !== false && (
           <div key="header" data-rsbs-header ref={headerRef} {...bind()}>
-            <div data-rsbs-header-padding>{header}</div>
+            {header}
           </div>
         )}
         <div key="content" data-rsbs-content ref={contentRef}>
@@ -551,12 +551,12 @@ export const BottomSheet = React.forwardRef<
             // The overflow hidden is for the resize observer to get dimensions including margins and paddings
             style={{ overflow: 'hidden' }}
           >
-            <div data-rsbs-content-padding>{children}</div>
+            {children}
           </div>
         </div>
         {footer && (
           <div key="footer" ref={footerRef} data-rsbs-footer {...bind()}>
-            <div data-rsbs-footer-padding>{footer}</div>
+            {footer}
           </div>
         )}
       </div>

--- a/src/BottomSheet.tsx
+++ b/src/BottomSheet.tsx
@@ -90,7 +90,7 @@ export const BottomSheet = React.forwardRef<
 
   const containerRef = useRef<HTMLDivElement>(null)
   const scrollRef = useRef<HTMLDivElement>(null)
-  const contentContainerRef = useRef<HTMLDivElement>(null)
+  const contentRef = useRef<HTMLDivElement>(null)
   const headerRef = useRef<HTMLDivElement>(null)
   const footerRef = useRef<HTMLDivElement>(null)
   const overlayRef = useRef<HTMLDivElement | null>(null)
@@ -118,7 +118,7 @@ export const BottomSheet = React.forwardRef<
   })
 
   const { minSnap, maxSnap, maxHeight, findSnap } = useSnapPoints({
-    contentContainerRef,
+    contentRef,
     controlledMaxHeight,
     footerEnabled: !!footer,
     footerRef,
@@ -546,7 +546,7 @@ export const BottomSheet = React.forwardRef<
           </div>
         )}
         <div key="scroll" data-rsbs-scroll ref={scrollRef}>
-          <div data-rsbs-content ref={contentContainerRef}>
+          <div data-rsbs-content ref={contentRef}>
             {children}
           </div>
         </div>

--- a/src/hooks/useSnapPoints.tsx
+++ b/src/hooks/useSnapPoints.tsx
@@ -13,7 +13,7 @@ import { useReady } from './useReady'
 import { ResizeObserverOptions } from '@juggle/resize-observer/lib/ResizeObserverOptions'
 
 export function useSnapPoints({
-  contentContainerRef,
+  contentRef,
   controlledMaxHeight,
   footerEnabled,
   footerRef,
@@ -25,7 +25,7 @@ export function useSnapPoints({
   ready,
   registerReady,
 }: {
-  contentContainerRef: React.RefObject<Element>
+  contentRef: React.RefObject<Element>
   controlledMaxHeight?: number
   footerEnabled: boolean
   footerRef: React.RefObject<Element>
@@ -38,7 +38,7 @@ export function useSnapPoints({
   registerReady: ReturnType<typeof useReady>['registerReady']
 }) {
   const { maxHeight, minHeight, headerHeight, footerHeight } = useDimensions({
-    contentContainerRef,
+    contentRef: contentRef,
     controlledMaxHeight,
     footerEnabled,
     footerRef,
@@ -93,7 +93,7 @@ export function useSnapPoints({
 }
 
 function useDimensions({
-  contentContainerRef,
+  contentRef,
   controlledMaxHeight,
   footerEnabled,
   footerRef,
@@ -101,7 +101,7 @@ function useDimensions({
   headerRef,
   registerReady,
 }: {
-  contentContainerRef: React.RefObject<Element>
+  contentRef: React.RefObject<Element>
   controlledMaxHeight?: number
   footerEnabled: boolean
   footerRef: React.RefObject<Element>
@@ -119,7 +119,7 @@ function useDimensions({
     label: 'headerHeight',
     enabled: headerEnabled,
   })
-  const contentHeight = useElementSizeObserver(contentContainerRef, {
+  const contentHeight = useElementSizeObserver(contentRef, {
     label: 'contentHeight',
     enabled: true,
   })

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -65,18 +65,21 @@ export const BottomSheet = forwardRef<RefHandles, Props>(function BottomSheet(
     [onSpringEnd]
   )
 
+  // This isn't just a performance optimization, it's also to avoid issues when running a non-browser env like SSR
+  if (!mounted) {
+    return null
+  }
+
   return (
     <Portal data-rsbs-portal>
-      {mounted && (
-        <_BottomSheet
-          {...props}
-          lastSnapRef={lastSnapRef}
-          ref={ref}
-          initialState={initialStateRef.current}
-          onSpringStart={handleSpringStart}
-          onSpringEnd={handleSpringEnd}
-        />
-      )}
+      <_BottomSheet
+        {...props}
+        lastSnapRef={lastSnapRef}
+        ref={ref}
+        initialState={initialStateRef.current}
+        onSpringStart={handleSpringStart}
+        onSpringEnd={handleSpringEnd}
+      />
     </Portal>
   )
 })

--- a/src/style.css
+++ b/src/style.css
@@ -25,15 +25,12 @@
 [data-rsbs-backdrop],
 [data-rsbs-antigap] {
   z-index: 3;
-  -ms-scroll-chaining: none;
   overscroll-behavior: none;
   touch-action: none;
   position: fixed;
   right: 0;
   bottom: 0;
   left: 0;
-  -webkit-user-select: none;
-  -ms-user-select: none;
   user-select: none;
   -webkit-tap-highlight-color: transparent;
   -webkit-touch-callout: none;
@@ -66,8 +63,6 @@
 }
 [data-rsbs-header] {
   text-align: center;
-  -webkit-user-select: none;
-  -ms-user-select: none;
   user-select: none;
   box-shadow: 0 1px 0
     rgba(46, 59, 66, calc(var(--rsbs-content-opacity) * 0.125));
@@ -105,7 +100,6 @@
   -ms-user-select: auto;
   user-select: auto;
   overflow: auto;
-  -ms-scroll-chaining: none;
   overscroll-behavior: contain;
   -webkit-overflow-scrolling: touch;
 }

--- a/src/style.css
+++ b/src/style.css
@@ -62,9 +62,6 @@
 [data-rsbs-header] {
   flex-shrink: 0;
   cursor: ns-resize;
-}
-[data-rsbs-footer-padding],
-[data-rsbs-header-padding] {
   padding: 16px;
 }
 [data-rsbs-header] {
@@ -75,8 +72,6 @@
   box-shadow: 0 1px 0
     rgba(46, 59, 66, calc(var(--rsbs-content-opacity) * 0.125));
   z-index: 1;
-}
-[data-rsbs-header-padding] {
   padding-top: calc(20px + env(safe-area-inset-top));
   padding-bottom: 8px;
 }
@@ -99,8 +94,6 @@
 }
 [data-rsbs-has-header='false'] [data-rsbs-header] {
   box-shadow: none;
-}
-[data-rsbs-has-header='false'] [data-rsbs-header-padding] {
   padding-top: calc(12px + env(safe-area-inset-top));
 }
 [data-rsbs-content] {
@@ -119,7 +112,7 @@
 [data-rsbs-content]:focus {
   outline: none;
 }
-[data-rsbs-has-footer='false'] [data-rsbs-content-padding] {
+[data-rsbs-has-footer='false'] [data-rsbs-content] {
   padding-bottom: env(safe-area-inset-bottom);
 }
 [data-rsbs-footer] {
@@ -127,15 +120,12 @@
     0 2px 0 var(--rsbs-bg);
   overflow: hidden;
   z-index: 1;
-}
-[data-rsbs-footer-padding] {
   padding-bottom: calc(16px + env(safe-area-inset-bottom));
 }
 
 [data-rsbs-is-dismissable='true'],
 [data-rsbs-is-dismissable='false']:matches([data-rsbs-state='opening'], [data-rsbs-state='closing']) {
-  &
-    :matches([data-rsbs-header-padding], [data-rsbs-content-padding], [data-rsbs-footer-padding]) {
+  & :matches([data-rsbs-header], [data-rsbs-content], [data-rsbs-footer]) > * {
     opacity: var(--rsbs-content-opacity);
   }
   & [data-rsbs-backdrop] {

--- a/src/style.css
+++ b/src/style.css
@@ -16,14 +16,14 @@
     0 -1px 0 rgba(38, 89, 115, 0.05);
 }
 [data-rsbs-overlay],
-[data-rsbs-antigap] {
+[data-rsbs-root]:after {
   max-width: var(--rsbs-max-w);
   margin-left: var(--rsbs-ml);
   margin-right: var(--rsbs-mr);
 }
 [data-rsbs-overlay],
 [data-rsbs-backdrop],
-[data-rsbs-antigap] {
+[data-rsbs-root]:after {
   z-index: 3;
   overscroll-behavior: none;
   touch-action: none;
@@ -47,7 +47,8 @@
   cursor: ns-resize;
 }
 
-[data-rsbs-antigap] {
+[data-rsbs-root]:after {
+  content: '';
   pointer-events: none;
   background: var(--rsbs-bg);
   height: 1px;

--- a/src/style.css
+++ b/src/style.css
@@ -96,7 +96,7 @@
   box-shadow: none;
   padding-top: calc(12px + env(safe-area-inset-top));
 }
-[data-rsbs-content] {
+[data-rsbs-scroll] {
   flex-shrink: 1;
   flex-grow: 1;
   -webkit-tap-highlight-color: revert;
@@ -109,11 +109,15 @@
   overscroll-behavior: contain;
   -webkit-overflow-scrolling: touch;
 }
-[data-rsbs-content]:focus {
+[data-rsbs-scroll]:focus {
   outline: none;
 }
-[data-rsbs-has-footer='false'] [data-rsbs-content] {
+[data-rsbs-has-footer='false'] [data-rsbs-scroll] {
   padding-bottom: env(safe-area-inset-bottom);
+}
+[data-rsbs-content] {
+  /* The overflow hidden is to ensure any margin on child nodes are included when the resize observer is measuring the height */
+  overflow: hidden;
 }
 [data-rsbs-footer] {
   box-shadow: 0 -1px 0 rgba(46, 59, 66, calc(var(--rsbs-content-opacity) * 0.125)),
@@ -125,7 +129,7 @@
 
 [data-rsbs-is-dismissable='true'],
 [data-rsbs-is-dismissable='false']:matches([data-rsbs-state='opening'], [data-rsbs-state='closing']) {
-  & :matches([data-rsbs-header], [data-rsbs-content], [data-rsbs-footer]) > * {
+  & :matches([data-rsbs-header], [data-rsbs-scroll], [data-rsbs-footer]) > * {
     opacity: var(--rsbs-content-opacity);
   }
   & [data-rsbs-backdrop] {


### PR DESCRIPTION
BREAKING CHANGE:
The resize observer logic is rewritten to no longer require wrapper elements like `[data-rsbs-footer-padding]`. If you're not using custom CSS and are simply importing `react-spring-bottom-sheet/dist/style.css` in your app then this isn't a breaking change for you.


If you're using custom CSS, here's the breaking changes:
- `[data-rsbs-header-padding]` removed, update selectors to `[data-rsbs-header]`
- `[data-rsbs-content-padding]` removed, update selectors to `[data-rsbs-scroll]`
- `[data-rsbs-footer-padding]` removed, update selectors to `[data-rsbs-footer]`
- `[data-rsbs-antigap]` removed, update selectors to `[data-rsbs-root]:after` and make sure to add `content: '';`.
- `[data-rsbs-content]` is changed, update selectors to `[data-rsbs-scroll]`.
- The `<div style="overflow:hidden;">` wrapper that used to be between `[data-rsbs-content]` and `[data-rsbs-content-padding]` is now within `[data-rsbs-scroll]`, and no longer hardcode `overflow: hidden`, add `[data-rsbs-content] { overflow: hidden; }` to your CSS.