### PR TITLE
feat: allow the developer to disable focus trap

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,9 +122,11 @@ Supports the same value type as the `sibling` prop. Renders the node as a child 
 
 ### initialFocusRef
 
-Type: `React.Ref`
+Type: `React.Ref | false`
 
-A react ref to the element you want to get keyboard focus when opening. If not provided it's automatically selecting the first interactive element it finds.
+A react ref to the element you want to get keyboard focus when opening.
+If not provided it's automatically selecting the first interactive element it finds.
+If set to false keyboard focus when opening is disabled.
 
 ### blocking
 

--- a/src/BottomSheet.tsx
+++ b/src/BottomSheet.tsx
@@ -118,8 +118,8 @@ export const BottomSheet = React.forwardRef<
   const focusTrapRef = useFocusTrap({
     targetRef: containerRef,
     fallbackRef: overlayRef,
-    initialFocusRef,
-    enabled: ready && blocking,
+    initialFocusRef: initialFocusRef || undefined,
+    enabled: ready && blocking && initialFocusRef !== false,
   })
 
   const { minSnap, maxSnap, maxHeight, findSnap } = useSnapPoints({

--- a/src/types.ts
+++ b/src/types.ts
@@ -91,8 +91,11 @@ export type Props = {
    */
   header?: React.ReactNode | false
 
-  /** A reference to the element that should be focused. By default it'll be the first interactive element. */
-  initialFocusRef?: React.RefObject<HTMLElement>
+  /**
+   * A reference to the element that should be focused. By default it'll be the first interactive element.
+   * Set to false to disable keyboard focus when opening.
+   */
+  initialFocusRef?: React.RefObject<HTMLElement> | false
 
   /**
    * Handler that is called when the user presses *esc*, clicks outside the dialog or drags the sheet to the bottom of the display.


### PR DESCRIPTION
This PR enables the developer to disable the focus trap by setting `initialFocusRef` to `false`.

This is useful when there is multiple focus traps. When a modal gets its focus trap back, settings `initialFocusRef` to `false` prevent it from jumping to top.