### PR TITLE
feat: expand on content drag

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,12 @@ Type: `boolean`
 
 iOS Safari, and some other mobile culprits, can be tricky if you're on a page that has scrolling overflow on `document.body`. Mobile browsers often prefer scrolling the page in these cases instead of letting you handle the touch interaction for UI such as the bottom sheet. Thus it's enabled by default. However it can be a bit agressive and can affect cases where you're putting a drag and drop element inside the bottom sheet. Such as `<input type="range" />` and more. For these cases you can wrap them in a container and give them this data attribute `[data-body-scroll-lock-ignore]` to prevent intervention. Really handy if you're doing crazy stuff like putting mapbox-gl widgets inside bottom sheets.
 
+### expandOnContentDrag
+
+Type: `boolean`
+
+Disabled by default. By default, a user can expand the bottom sheet only by dragging a header or the overlay. This option enables expanding the bottom sheet on the content dragging.
+
 ## Events
 
 All events receive `SpringEvent` as their argument. The payload varies, but `type` is always present, which can be `'OPEN' | 'RESIZE' | 'SNAP' | 'CLOSE'` depending on the scenario.

--- a/pages/fixtures/scrollable.tsx
+++ b/pages/fixtures/scrollable.tsx
@@ -1,6 +1,6 @@
 import cx from 'classnames'
 import type { NextPage } from 'next'
-import { useRef } from 'react'
+import { useRef, useState } from 'react'
 import scrollIntoView from 'smooth-scroll-into-view-if-needed'
 import Button from '../../docs/fixtures/Button'
 import CloseExample from '../../docs/fixtures/CloseExample'
@@ -55,6 +55,7 @@ const ScrollableFixturePage: NextPage<GetStaticProps> = ({
   meta,
   name,
 }) => {
+  const [expandOnContentDrag, setExpandOnContentDrag] = useState(true)
   const focusRef = useRef<HTMLButtonElement>()
   const sheetRef = useRef<BottomSheetRef>()
 
@@ -95,6 +96,7 @@ const ScrollableFixturePage: NextPage<GetStaticProps> = ({
             maxHeight / 4,
             maxHeight * 0.6,
           ]}
+          expandOnContentDrag={expandOnContentDrag}
         >
           <SheetContent>
             <div className="grid grid-cols-3 w-full gap-4">
@@ -135,6 +137,17 @@ const ScrollableFixturePage: NextPage<GetStaticProps> = ({
                 }
               >
                 Bottom
+              </Button>
+            </div>
+            <div className="grid w-full">
+              <Button
+                  className={[
+                    ' text-sm px-2 py-1',
+                    { 'text-xl': false, 'px-7': false, 'py-3': false },
+                  ]}
+                  onClick={() => setExpandOnContentDrag(!expandOnContentDrag)}
+                >
+                {expandOnContentDrag ? 'Disable' : 'Enable'} expand on content drag
               </Button>
             </div>
             <p>

--- a/src/types.ts
+++ b/src/types.ts
@@ -143,7 +143,13 @@ export type Props = {
   /**
    * Open immediatly instead of initially animating from a closed => open state, useful if the bottom sheet is visible by default and the animation would be distracting
    */
-  skipInitialTransition?: boolean
+  skipInitialTransition?: boolean,
+
+  /**
+   * Expand the bottom sheet on the content dragging. By default user can expand the bottom sheet only by dragging the header or overlay. This option enables expanding on dragging the content.
+   * @default expandOnContentDrag === false
+   */
+  expandOnContentDrag?: boolean,
 } & Omit<React.PropsWithoutRef<JSX.IntrinsicElements['div']>, 'children'>
 
 export interface RefHandles {


### PR DESCRIPTION
It works a little harshly on iOS devices because they have the overscroll that cannot be smoothly disabled.
BUT! It works in my opinion good enough to use it if it's critical for the project.

If somebody needs it before it's merged or declined I've already uploaded the feature on NPM: 
https://www.npmjs.com/package/n1k1tk-react-spring-bottom-sheet
It will be removed from npm after it's merged or stay if declined.

![ezgif-7-501c21bb50c5](https://user-images.githubusercontent.com/2446589/122687581-dd16a500-d21f-11eb-9fcc-7bd5f335b0a4.gif)
