### PR TITLE
fix: allow to use a bottom sheet inside another one

### DIFF
--- a/pages/fixtures/scrollable.tsx
+++ b/pages/fixtures/scrollable.tsx
@@ -56,8 +56,10 @@ const ScrollableFixturePage: NextPage<GetStaticProps> = ({
   name,
 }) => {
   const [expandOnContentDrag, setExpandOnContentDrag] = useState(true)
+  const [isInnerOpened, setIsInnerOpened] = useState(false);
   const focusRef = useRef<HTMLButtonElement>()
   const sheetRef = useRef<BottomSheetRef>()
+  const innerSheetRef = useRef<BottomSheetRef>()
 
   return (
     <>
@@ -89,7 +91,7 @@ const ScrollableFixturePage: NextPage<GetStaticProps> = ({
           skipInitialTransition
           sibling={<CloseExample className="z-10" />}
           ref={sheetRef}
-          initialFocusRef={focusRef}
+          initialFocusRef={isInnerOpened ? false : focusRef}
           defaultSnap={({ maxHeight }) => maxHeight / 2}
           snapPoints={({ maxHeight }) => [
             maxHeight - maxHeight / 10,
@@ -150,6 +152,17 @@ const ScrollableFixturePage: NextPage<GetStaticProps> = ({
                 {expandOnContentDrag ? 'Disable' : 'Enable'} expand on content drag
               </Button>
             </div>
+            <div className="grid w-full">
+              <Button
+                  className={[
+                    ' text-sm px-2 py-1',
+                    { 'text-xl': false, 'px-7': false, 'py-3': false },
+                  ]}
+                  onClick={() => setIsInnerOpened(!isInnerOpened)}
+                >
+                {isInnerOpened ? 'Close' : 'Open'} inner sheet
+              </Button>
+            </div>
             <p>
               The sheet will always try to set initial focus on the first
               interactive element it finds.
@@ -172,6 +185,35 @@ const ScrollableFixturePage: NextPage<GetStaticProps> = ({
               }}
             />
           </SheetContent>
+
+          <BottomSheet
+            open={isInnerOpened}
+            skipInitialTransition
+            ref={innerSheetRef}
+            blocking={false}
+            initialFocusRef={false}
+            onDismiss={() => setIsInnerOpened(false)}
+            defaultSnap={({ maxHeight }) => maxHeight / 2}
+            snapPoints={({ maxHeight }) => [
+              maxHeight / 4,
+              maxHeight * 0.4,
+            ]}
+            expandOnContentDrag={true}
+          >
+            <SheetContent>
+            <p>You may need to use a sheet inside another sheet.</p>
+            <p>
+              <Code>expandOnContentDrag</Code> prop on a child sheet won't work
+              if <Code>initialFocusRef</Code> prop on a parent is set to true.
+            </p>
+              {rows.map(({ key, bg, w }) => (
+                <div
+                  key={`row-${key}`}
+                  className={cx('block rounded-md h-8', bg, w)}
+                />
+              ))}
+            </SheetContent>
+          </BottomSheet>
         </BottomSheet>
       </Container>
     </>

--- a/src/BottomSheet.tsx
+++ b/src/BottomSheet.tsx
@@ -481,6 +481,7 @@ export const BottomSheet = React.forwardRef<
 
   const handleDrag = ({
     args: [{ closeOnTap = false, isContentDragging = false } = {}] = [],
+    event,
     cancel,
     direction: [, direction],
     down,
@@ -491,6 +492,10 @@ export const BottomSheet = React.forwardRef<
     tap,
     velocity,
   }) => {
+    if (!containerRef.current.contains(event.target)) {
+      return;
+    }
+
     const my = _my * -1
 
     // Cancel the drag operation if the canDrag state changed


### PR DESCRIPTION
We have a huge form inside the bottom sheet on the project. And some fields inside the form are very complex and may have another bottom sheet inside the parent where the form is.

I tried to use `domTarget` option on `useDrag` function but it works not exactly as we need. Refactor without direct bindings can help, but I don't think it's too critical to have a multiple events on a different elements.