### PR TITLE
Fix backdrop clicks propagating through on iOS

### DIFF
--- a/src/BottomSheet.tsx
+++ b/src/BottomSheet.tsx
@@ -502,8 +502,6 @@ export const BottomSheet = React.forwardRef<
 
     if (onDismiss && closeOnTap && tap) {
       cancel()
-      // Runs onDismiss in a timeout to avoid tap events on the backdrop from triggering click events on elements underneath
-      setTimeout(() => onDismiss(), 0)
       return memo
     }
 
@@ -644,6 +642,7 @@ export const BottomSheet = React.forwardRef<
           key="backdrop"
           data-rsbs-backdrop
           {...bind({ closeOnTap: true })}
+          onClick={() => onDismiss()}
         />
       )}
       <div


### PR DESCRIPTION
I've tested this fairly extensively on both the example site and my own usage.

To reproduce:

Open the [this page](https://react-spring.bottom-sheet.dev/fixtures/simple) on the documentation site and try to click the 'Close Example' button covered by the backdrop on iOS safari. This PR should prevent that button from being triggered when the bottom sheet is open.

Resolves #180.