### PR TITLE
Fix Incorrect aria-modal Usage

### DIFF
--- a/src/BottomSheet.tsx
+++ b/src/BottomSheet.tsx
@@ -648,7 +648,7 @@ export const BottomSheet = React.forwardRef<
       )}
       <div
         key="overlay"
-        aria-modal="true"
+        aria-modal={blocking}
         role="dialog"
         data-rsbs-overlay
         tabIndex={-1}


### PR DESCRIPTION
This PR sets the value of the `aria-modal` attribute based on the value of the `blocking` prop. According to the [MDN Web Docs](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-modal) the `aria-modal` attribute is designed to limit screen readers to a particular area of an application. Therefore I think it makes sense that it should be set in line with the `blocking` prop.

Without this fix there is no way to set `aria-modal` to `false` therefore screen readers which respect the attribute (currently only iOS as far as I know) will always be stuck in the bottom sheet.