### PR TITLE
fix: add `SpringConfig` as Props

### DIFF
--- a/src/BottomSheet.tsx
+++ b/src/BottomSheet.tsx
@@ -69,6 +69,7 @@ export const BottomSheet = React.forwardRef<
     onSpringEnd,
     reserveScrollBarGap = blocking,
     expandOnContentDrag = false,
+    springConfig,
     ...props
   },
   forwardRef
@@ -157,7 +158,7 @@ export const BottomSheet = React.forwardRef<
   // New utility for using events safely
   const asyncSet = useCallback<typeof set>(
     // @ts-expect-error
-    ({ onRest, config: { velocity = 1, ...config } = {}, ...opts }) =>
+    ({ onRest, config: { velocity = 1,...config } = {}, ...opts }) =>
       new Promise((resolve) =>
         set({
           ...opts,
@@ -173,6 +174,7 @@ export const BottomSheet = React.forwardRef<
               friction,
               friction + (friction - friction * velocity)
             ),
+            ...springConfig,
           },
           onRest: (...args) => {
             resolve(...args)
@@ -180,7 +182,7 @@ export const BottomSheet = React.forwardRef<
           },
         })
       ),
-    [set]
+    [set, springConfig]
   )
   const [current, send] = useMachine(overlayMachine, {
     devTools: debugging,

--- a/src/BottomSheet.tsx
+++ b/src/BottomSheet.tsx
@@ -158,7 +158,7 @@ export const BottomSheet = React.forwardRef<
   // New utility for using events safely
   const asyncSet = useCallback<typeof set>(
     // @ts-expect-error
-    ({ onRest, config: { velocity = 1,...config } = {}, ...opts }) =>
+    ({ onRest, config: { velocity = 1, ...config } = {}, ...opts }) =>
       new Promise((resolve) =>
         set({
           ...opts,

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,3 +1,5 @@
+import { SpringConfig } from "react-spring";
+
 export type SnapPointProps = {
   /**
    * The height of the sticky header, if there's one
@@ -150,7 +152,7 @@ export type Props = {
    * @default expandOnContentDrag === false
    */
   expandOnContentDrag?: boolean,
-} & Omit<React.PropsWithoutRef<JSX.IntrinsicElements['div']>, 'children'>
+} & Omit<React.PropsWithoutRef<JSX.IntrinsicElements['div']>, 'children'> & { springConfig?: SpringConfig }
 
 export interface RefHandles {
   /**


### PR DESCRIPTION
I received a feedback from my design team, that if I could change the transition duration.
After looking through the source code, I found that passing `SpringConfig` is not supported yet.

Please commit more if necesary.

This PR is related to #151 and #30.