### PR TITLE
Forward dialog aria labelling props to overlay

### DIFF
--- a/src/BottomSheet.tsx
+++ b/src/BottomSheet.tsx
@@ -69,6 +69,9 @@ export const BottomSheet = React.forwardRef<
     onSpringEnd,
     reserveScrollBarGap = blocking,
     expandOnContentDrag = false,
+    'aria-label': ariaLabel,
+    'aria-labelledby': ariaLabelledBy,
+    'aria-describedby': ariaDescribedBy,
     ...props
   },
   forwardRef
@@ -649,6 +652,9 @@ export const BottomSheet = React.forwardRef<
       <div
         key="overlay"
         aria-modal="true"
+        aria-label={ariaLabel}
+        aria-labelledby={ariaLabelledBy}
+        aria-describedby={ariaDescribedBy}
         role="dialog"
         data-rsbs-overlay
         tabIndex={-1}


### PR DESCRIPTION
## Summary
- forward `aria-label`, `aria-labelledby`, and `aria-describedby` to the element with `role="dialog"`
- keep other props on the root bottom sheet container

Fixes #13